### PR TITLE
Enable decorated methods to return values

### DIFF
--- a/docs/interfaces/CreateDestroy.CreateDestroy-1.html
+++ b/docs/interfaces/CreateDestroy.CreateDestroy-1.html
@@ -137,7 +137,7 @@
 					<a name="destroy" class="tsd-anchor"></a>
 					<h3>destroy</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">destroy<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">destroy<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -152,7 +152,7 @@
 									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/docs/interfaces/CreateDestroyStartStop.CreateDestroyStartStop-1.html
+++ b/docs/interfaces/CreateDestroyStartStop.CreateDestroyStartStop-1.html
@@ -157,7 +157,7 @@
 					<a name="destroy" class="tsd-anchor"></a>
 					<h3>destroy</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">destroy<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">destroy<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -172,7 +172,7 @@
 									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>
@@ -180,7 +180,7 @@
 					<a name="start" class="tsd-anchor"></a>
 					<h3>start</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -195,7 +195,7 @@
 									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>
@@ -203,7 +203,7 @@
 					<a name="stop" class="tsd-anchor"></a>
 					<h3>stop</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">stop<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">stop<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -218,7 +218,7 @@
 									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/docs/interfaces/StartStop.StartStop-1.html
+++ b/docs/interfaces/StartStop.StartStop-1.html
@@ -138,7 +138,7 @@
 					<a name="start" class="tsd-anchor"></a>
 					<h3>start</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -153,7 +153,7 @@
 									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>
@@ -161,7 +161,7 @@
 					<a name="stop" class="tsd-anchor"></a>
 					<h3>stop</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">stop<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">stop<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -176,7 +176,7 @@
 									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/src/CreateDestroy.ts
+++ b/src/CreateDestroy.ts
@@ -7,14 +7,14 @@ import { ErrorAsyncInitDestroyed } from './errors';
 
 interface CreateDestroy {
   get destroyed(): boolean;
-  destroy(...args: Array<any>): Promise<void>;
+  destroy(...args: Array<any>): Promise<any>;
 }
 
 function CreateDestroy() {
   return <
     T extends {
       new (...args: any[]): {
-        destroy?(...args: Array<any>): Promise<void>;
+        destroy?(...args: Array<any>): Promise<any>;
       };
     },
   >(
@@ -27,14 +27,14 @@ function CreateDestroy() {
         return this._destroyed;
       }
 
-      public async destroy(...args: Array<any>): Promise<void> {
+      public async destroy(...args: Array<any>): Promise<any> {
         try {
           if (this._destroyed) {
             return;
           }
           this._destroyed = true;
           if (typeof super['destroy'] === 'function') {
-            await super.destroy(...args);
+            return await super.destroy(...args);
           }
         } catch (e) {
           this._destroyed = false;

--- a/src/CreateDestroyStartStop.ts
+++ b/src/CreateDestroyStartStop.ts
@@ -12,9 +12,9 @@ import {
 interface CreateDestroyStartStop {
   get running(): boolean;
   get destroyed(): boolean;
-  start(...args: Array<any>): Promise<void>;
-  stop(...args: Array<any>): Promise<void>;
-  destroy(...args: Array<any>): Promise<void>;
+  start(...args: Array<any>): Promise<any>;
+  stop(...args: Array<any>): Promise<any>;
+  destroy(...args: Array<any>): Promise<any>;
 }
 
 function CreateDestroyStartStop(
@@ -24,9 +24,9 @@ function CreateDestroyStartStop(
   return <
     T extends {
       new (...args: any[]): {
-        start?(...args: Array<any>): Promise<void>;
-        stop?(...args: Array<any>): Promise<void>;
-        destroy?(...args: Array<any>): Promise<void>;
+        start?(...args: Array<any>): Promise<any>;
+        stop?(...args: Array<any>): Promise<any>;
+        destroy?(...args: Array<any>): Promise<any>;
       };
     },
   >(
@@ -44,7 +44,7 @@ function CreateDestroyStartStop(
         return this._destroyed;
       }
 
-      public async destroy(...args: Array<any>): Promise<void> {
+      public async destroy(...args: Array<any>): Promise<any> {
         try {
           if (this._destroyed) {
             return;
@@ -54,7 +54,7 @@ function CreateDestroyStartStop(
           }
           this._destroyed = true;
           if (typeof super['destroy'] === 'function') {
-            await super.destroy(...args);
+            return await super.destroy(...args);
           }
         } catch (e) {
           this._destroyed = false;
@@ -62,7 +62,7 @@ function CreateDestroyStartStop(
         }
       }
 
-      public async start(...args: Array<any>): Promise<void> {
+      public async start(...args: Array<any>): Promise<any> {
         try {
           if (this._running) {
             return;
@@ -72,7 +72,7 @@ function CreateDestroyStartStop(
           }
           this._running = true;
           if (typeof super['start'] === 'function') {
-            await super.start(...args);
+            return await super.start(...args);
           }
         } catch (e) {
           this._running = false;
@@ -80,7 +80,7 @@ function CreateDestroyStartStop(
         }
       }
 
-      public async stop(...args: Array<any>): Promise<void> {
+      public async stop(...args: Array<any>): Promise<any> {
         try {
           if (!this._running) {
             return;
@@ -92,7 +92,7 @@ function CreateDestroyStartStop(
           }
           this._running = false;
           if (typeof super['stop'] === 'function') {
-            await super.stop(...args);
+            return await super.stop(...args);
           }
         } catch (e) {
           this._running = true;

--- a/src/StartStop.ts
+++ b/src/StartStop.ts
@@ -7,16 +7,16 @@ import { ErrorAsyncInitNotRunning } from './errors';
 
 interface StartStop {
   get running(): boolean;
-  start(...args: Array<any>): Promise<void>;
-  stop(...args: Array<any>): Promise<void>;
+  start(...args: Array<any>): Promise<any>;
+  stop(...args: Array<any>): Promise<any>;
 }
 
 function StartStop() {
   return <
     T extends {
       new (...args: any[]): {
-        start?(...args: Array<any>): Promise<void>;
-        stop?(...args: Array<any>): Promise<void>;
+        start?(...args: Array<any>): Promise<any>;
+        stop?(...args: Array<any>): Promise<any>;
       };
     },
   >(
@@ -29,14 +29,14 @@ function StartStop() {
         return this._running;
       }
 
-      public async start(...args: Array<any>): Promise<void> {
+      public async start(...args: Array<any>): Promise<any> {
         try {
           if (this._running) {
             return;
           }
           this._running = true;
           if (typeof super['start'] === 'function') {
-            await super.start(...args);
+            return await super.start(...args);
           }
         } catch (e) {
           this._running = false;
@@ -44,14 +44,14 @@ function StartStop() {
         }
       }
 
-      public async stop(...args: Array<any>) {
+      public async stop(...args: Array<any>): Promise<any> {
         try {
           if (!this._running) {
             return;
           }
           this._running = false;
           if (typeof super['stop'] === 'function') {
-            await super.stop(...args);
+            return await super.stop(...args);
           }
         } catch (e) {
           this._running = true;

--- a/tests/CreateDestroyStartStop.test.ts
+++ b/tests/CreateDestroyStartStop.test.ts
@@ -27,8 +27,9 @@ describe('CreateDestroyStartStop', () => {
         constructorMock();
       }
 
-      public async start(): Promise<void> {
+      public async start(): Promise<string> {
         startMock();
+        return 'hello world';
       }
 
       public async stop(): Promise<void> {


### PR DESCRIPTION
### Description

This allows `start`, `stop`, and `destroy` methods to all return any type rather than enforcing `void`. This can be useful when certain methods should return some useful information.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build