### PR TITLE
feat: any errors thrown by the decorators provides a useful call stack

### DIFF
--- a/src/CreateDestroy.ts
+++ b/src/CreateDestroy.ts
@@ -93,15 +93,18 @@ function ready(
         if (block) {
           return this[initLock].withReadF(async () => {
             if (this[_destroyed]) {
+              errorDestroyed.stack = new Error().stack ?? '';
               throw errorDestroyed;
             }
             return f.apply(this, args);
           });
         } else {
           if (this[initLock].isLocked()) {
+            errorDestroyed.stack = new Error().stack ?? '';
             throw errorDestroyed;
           }
           if (this[_destroyed]) {
+            errorDestroyed.stack = new Error().stack ?? '';
             throw errorDestroyed;
           }
           return f.apply(this, args);
@@ -112,9 +115,11 @@ function ready(
         // If locked, it is during destroy
         // Consider it already destroyed
         if (this[initLock].isLocked()) {
+          errorDestroyed.stack = new Error().stack ?? '';
           throw errorDestroyed;
         }
         if (this[_destroyed]) {
+          errorDestroyed.stack = new Error().stack ?? '';
           throw errorDestroyed;
         }
         yield* f.apply(this, args);
@@ -124,15 +129,18 @@ function ready(
         if (block) {
           yield* this[initLock].withReadG(() => {
             if (this[_destroyed]) {
+              errorDestroyed.stack = new Error().stack ?? '';
               throw errorDestroyed;
             }
             return f.apply(this, args);
           });
         } else {
           if (this[initLock].isLocked()) {
+            errorDestroyed.stack = new Error().stack ?? '';
             throw errorDestroyed;
           }
           if (this[_destroyed]) {
+            errorDestroyed.stack = new Error().stack ?? '';
             throw errorDestroyed;
           }
           yield* f.apply(this, args);
@@ -143,9 +151,11 @@ function ready(
         // If locked, it is during destroy
         // Consider it already destroyed
         if (this[initLock].isLocked()) {
+          errorDestroyed.stack = new Error().stack ?? '';
           throw errorDestroyed;
         }
         if (this[_destroyed]) {
+          errorDestroyed.stack = new Error().stack ?? '';
           throw errorDestroyed;
         }
         return f.apply(this, args);

--- a/src/CreateDestroyStartStop.ts
+++ b/src/CreateDestroyStartStop.ts
@@ -77,6 +77,7 @@ function CreateDestroyStartStop<
               return;
             }
             if (this[_running]) {
+              errorRunning.stack = new Error().stack ?? '';
               throw errorRunning;
             }
             let result;
@@ -99,6 +100,7 @@ function CreateDestroyStartStop<
               return;
             }
             if (this[_destroyed]) {
+              errorDestroyed.stack = new Error().stack ?? '';
               throw errorDestroyed;
             }
             let result;
@@ -123,6 +125,7 @@ function CreateDestroyStartStop<
             if (this[_destroyed]) {
               // It is not possible to be running and destroyed
               // however this line is here for completion
+              errorDestroyed.stack = new Error().stack ?? '';
               throw errorDestroyed;
             }
             let result;
@@ -169,15 +172,18 @@ function ready(
         if (block) {
           return this[initLock].withReadF(async () => {
             if (!this[_running]) {
+              errorNotRunning.stack = new Error().stack ?? '';
               throw errorNotRunning;
             }
             return f.apply(this, args);
           });
         } else {
           if (this[initLock].isLocked()) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           if (!this[_running]) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           return f.apply(this, args);
@@ -186,9 +192,11 @@ function ready(
     } else if (f instanceof GeneratorFunction) {
       descriptor[kind] = function* (...args) {
         if (this[initLock].isLocked()) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         if (!this[_running]) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         yield* f.apply(this, args);
@@ -198,15 +206,18 @@ function ready(
         if (block) {
           yield* this[initLock].withReadG(() => {
             if (!this[_running]) {
+              errorNotRunning.stack = new Error().stack ?? '';
               throw errorNotRunning;
             }
             return f.apply(this, args);
           });
         } else {
           if (this[initLock].isLocked()) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           if (!this[_running]) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           yield* f.apply(this, args);
@@ -215,9 +226,11 @@ function ready(
     } else {
       descriptor[kind] = function (...args) {
         if (this[initLock].isLocked()) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         if (!this[_running]) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         return f.apply(this, args);

--- a/src/StartStop.ts
+++ b/src/StartStop.ts
@@ -114,15 +114,18 @@ function ready(
         if (block) {
           return this[initLock].withReadF(async () => {
             if (!this[_running]) {
+              errorNotRunning.stack = new Error().stack ?? '';
               throw errorNotRunning;
             }
             return f.apply(this, args);
           });
         } else {
           if (this[initLock].isLocked()) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           if (!this[_running]) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           return f.apply(this, args);
@@ -131,9 +134,11 @@ function ready(
     } else if (f instanceof GeneratorFunction) {
       descriptor[kind] = function* (...args) {
         if (this[initLock].isLocked()) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         if (!this[_running]) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         yield* f.apply(this, args);
@@ -143,15 +148,18 @@ function ready(
         if (block) {
           yield* this[initLock].withReadG(() => {
             if (!this[_running]) {
+              errorNotRunning.stack = new Error().stack ?? '';
               throw errorNotRunning;
             }
             return f.apply(this, args);
           });
         } else {
           if (this[initLock].isLocked()) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           if (!this[_running]) {
+            errorNotRunning.stack = new Error().stack ?? '';
             throw errorNotRunning;
           }
           yield* f.apply(this, args);
@@ -160,9 +168,11 @@ function ready(
     } else {
       descriptor[kind] = function (...args) {
         if (this[initLock].isLocked()) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         if (!this[_running]) {
+          errorNotRunning.stack = new Error().stack ?? '';
           throw errorNotRunning;
         }
         return f.apply(this, args);


### PR DESCRIPTION
### Description
The call stack for the running, not running and destroyed errors now gets updated just before getting thrown.

### Issues Fixed
* Fixes #10 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [X] 1. update the error's stack trace before throwing it.
- [X] 2. manually confirm that the error is providing useful stack information.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
